### PR TITLE
Add support for Narrow-Width Integer Sign Extension WASM opcodes

### DIFF
--- a/json2wasm.js
+++ b/json2wasm.js
@@ -217,6 +217,11 @@ const OPCODES = (_exports.OPCODES = {
   'i64.reinterpret/f64': 0xbd,
   'f32.reinterpret/i32': 0xbe,
   'f64.reinterpret/i64': 0xbf,
+  'i32.extend8_s': 0xc0,
+  'i32.extend16_s': 0xc1,
+  'i64.extend8_s': 0xc2,
+  'i64.extend16_s': 0xc3,
+  'i64.extend32_s': 0xc4
 });
 
 _exports.typeGenerators = {

--- a/wasm2json.js
+++ b/wasm2json.js
@@ -238,6 +238,13 @@ const OPCODES = _exports.OPCODES = {
   0xbd: 'i64.reinterpret/f64',
   0xbe: 'f32.reinterpret/i32',
   0xbf: 'f64.reinterpret/i64'
+
+  // Narrow-Width Integer Sign Extension
+  0xc0: 'i32.extend8_s',
+  0xc1: 'i32.extend16_s',
+  0xc2: 'i64.extend8_s',
+  0xc3: 'i64.extend16_s',
+  0xc4: 'i64.extend32_s'
 }
 
 const SECTION_IDS = _exports.SECTION_IDS = {


### PR DESCRIPTION
The WASM opcodes from the range `0xC0..0xC4` are excluded from the current version of this package, this PR adds support for them. See https://github.com/sunfishcode/wasm-reference-manual/blob/master/WebAssembly.md#narrow-width-integer-sign-extension.

This is required, for example, for https://github.com/warp-contracts/warp/issues/284#issuecomment-1359224307.